### PR TITLE
Add reuse lint check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ on:
     branches: [master]
 
 jobs:
+  reuse:
+    name: REUSE Compliance Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: fsfe/reuse-action@v1.1
+
   xrefcheck-self:
     name: Run this action on this repo
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 # Container image that runs your code
 FROM alpine:3.11
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 # GitHub Action for xrefcheck
 
+[![REUSE status](https://api.reuse.software/badge/github.com/serokell/xrefcheck-action)](https://api.reuse.software/info/github.com/serokell/xrefcheck-action)
+
 This repository contains a GitHub action that simplifies the usage of the [xrefcheck](https://github.com/serokell/xrefcheck) tool.
 
 ## Usage

--- a/action.yml
+++ b/action.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 name: 'xrefcheck'
 description: 'Check cross-references in your repository'
 author: 'Serokell'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 # This script downloads xrefcheck from GitHub releases, unpacks it
 # and optionally runs.
 # Inputs:


### PR DESCRIPTION
## Description

Problem: our best practices suggest checking that all our code
complies with the REUSE specification, but we don't test it
on CI.

Solution: add the corresponding check.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
