### PR TITLE
Add `0.2` version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,8 @@ jobs:
       uses: ./
       with:
         xrefcheck-version: 0.1.3
+
+    - name: Run 0.2
+      uses: ./
+      with:
+        xrefcheck-version: 0.2

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In a future version it may contain an absolute path.
 
 ### Example
 
-To run `xrefcheck-0.1.3` on your repository in the `local-only` mode:
+To run `xrefcheck-0.2` on your repository in the `local-only` mode:
 
 ```yaml
 jobs:
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: serokell/xrefcheck-action@v1
       with:
-        xrefcheck-version: 0.1.3
+        xrefcheck-version: 0.2
         xrefcheck-args: --mode local-only
 ```
 
@@ -50,6 +50,7 @@ jobs:
 <!-- Make sure to update ci.yml when you update this list -->
 - 0.1.2
 - 0.1.3
+- 0.2
 
 ## For Contributors
 


### PR DESCRIPTION
## Description


Problem: `0.2` version of `xrefcheck` has been released, would be nice
to make sure `xrefcheck-action` supports it and update the docs.

Solution: update the `README`, add new version to CI check.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
