### PR TITLE
Add version 0.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,8 @@ jobs:
       uses: ./
       with:
         xrefcheck-version: 0.2.1
+
+    - name: Run 0.2.2
+      uses: ./
+      with:
+        xrefcheck-version: 0.2.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM alpine:3.11
 # Install dependencies
 RUN apk update
 ## pass these flags to make the image smaller
-RUN apk --no-cache --virtual add bash wget
+RUN apk --no-cache --virtual add bash wget git
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ jobs:
         xrefcheck-args: --mode local-only
 ```
 
-### Supported versions
+### Supported xrefcheck versions
 
 <!-- Make sure to update ci.yml when you update this list -->
 - 0.1.2
 - 0.1.3
 - 0.2
 - 0.2.1
-- 0.2.2
+- 0.2.2: requires xrefcheck-action v1.0.3 or greater
 
 #### Updating supported versions
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In a future version it may contain an absolute path.
 
 ### Example
 
-To run `xrefcheck-0.2.1` on your repository in the `local-only` mode:
+To run `xrefcheck-0.2.2` on your repository in the `local-only` mode:
 
 ```yaml
 jobs:
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: serokell/xrefcheck-action@v1
       with:
-        xrefcheck-version: 0.2.1
+        xrefcheck-version: 0.2.2
         xrefcheck-args: --mode local-only
 ```
 
@@ -52,6 +52,7 @@ jobs:
 - 0.1.3
 - 0.2
 - 0.2.1
+- 0.2.2
 
 #### Updating supported versions
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,4 +49,4 @@ if [ "$need_run" == true ]; then
   set +x
 fi
 
-echo "::set-output name=xrefcheck-path::$xrefcheck_path"
+echo "xrefcheck-path=$xrefcheck_path" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

Make sure xrefcheck-action supports the recently released xrefcheck v0.2.2

As of this version, xrefcheck now requires git to be installed and available in the PATH.
So the github action will need to be updated to install git beforehand.

After this PR is merged, I'll create a v1.0.3 tag and move the v1 tag to `HEAD`.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
